### PR TITLE
feat(purchase): permitir edición de fecha de confirmación en OC

### DIFF
--- a/.github/custom_addons/purchase_edit_date/__manifest__.py
+++ b/.github/custom_addons/purchase_edit_date/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Editable Confirmation Date on Purchase Order',
+    'version': '18.0.1.0.0',
+    'summary': 'Permite editar la fecha de confirmación en pedidos de compra',
+    'category': 'Purchases',
+    'depends': ['purchase'],
+    'data': [
+        'views/purchase_order_view.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/.github/custom_addons/purchase_edit_date/views/purchase_order_view.xml
+++ b/.github/custom_addons/purchase_edit_date/views/purchase_order_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_purchase_order_form_edit_date" model="ir.ui.view">
+        <field name="name">purchase.order.form.edit.date</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <field name="date_approve" position="attributes">
+                <attribute name="readonly">0</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Este módulo permite editar el campo `Fecha de confirmación` (`date_approve`)
en los pedidos de compra, quitando el atributo readonly desde la vista.