### PR TITLE
feat(account): aplicar secuencia según plantilla del pedido de venta

### DIFF
--- a/custom_addons/account_invoice_sequence_by_sale_type/__init__.py
+++ b/custom_addons/account_invoice_sequence_by_sale_type/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_addons/account_invoice_sequence_by_sale_type/__manifest__.py
+++ b/custom_addons/account_invoice_sequence_by_sale_type/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Factura por tipo de venta',
+    'summary': 'Asigna automáticamente una secuencia personalizada a facturas según la plantilla del pedido de venta.',
+    'version': '1.0',
+    'author': 'GrupoHNN',
+    'website': 'https://www.grupohnn.com',
+    'category': 'Contabilidad',
+    'depends': ['account', 'sale'],
+    'description': """
+Este módulo asigna automáticamente una secuencia personalizada al crear una factura de cliente,
+según la plantilla utilizada en el pedido de venta de origen.
+    """,
+    'data': [
+        'data/ir_sequence_data.xml',
+        'views/sequence_templates.xml'
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/custom_addons/account_invoice_sequence_by_sale_type/models/__init__.py
+++ b/custom_addons/account_invoice_sequence_by_sale_type/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/custom_addons/account_invoice_sequence_by_sale_type/models/account_move.py
+++ b/custom_addons/account_invoice_sequence_by_sale_type/models/account_move.py
@@ -1,0 +1,48 @@
+from odoo import models, api
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Al crear una factura, se aplica la lógica de asignar secuencia si corresponde.
+        """
+        moves = super().create(vals_list)
+        for move in moves:
+            move._set_invoice_sequence_by_template()
+        return moves
+
+    def _set_invoice_sequence_by_template(self):
+        """
+        Asigna automáticamente una secuencia a la factura según la plantilla del pedido de venta.
+
+        Requisitos:
+        - Factura cliente (`out_invoice`)
+        - Estado borrador
+        - Con origen (`invoice_origin`)
+        - Sin nombre definido (name vacío, '/', o 'Borrador')
+        """
+        for record in self:
+            if (record.move_type == 'out_invoice' and
+                record.invoice_origin and
+                record.state == 'draft' and
+                (not record.name or record.name in ('/', 'Borrador'))):
+
+                sale_order = self.env['sale.order'].search([
+                    ('name', '=', record.invoice_origin)
+                ], limit=1)
+
+                if sale_order and sale_order.sale_order_template_id:
+                    template_name = sale_order.sale_order_template_id.name
+                    sequence_mapping = {
+                        'Alquiler': 'sequence_factura_alquiler',
+                        'Maquina': 'sequence_factura_maquina',
+                        'Recambio': 'sequence_factura_recambio',
+                        'Reparacion': 'sequence_factura_reparacion',
+                    }
+                    sequence_code = sequence_mapping.get(template_name)
+                    if sequence_code:
+                        sequence = self.env['ir.sequence'].sudo().next_by_code(sequence_code)
+                        if sequence:
+                            record.sudo().write({'name': sequence})


### PR DESCRIPTION
Qué hace el cambio:
Asigna automáticamente una secuencia personalizada a facturas según la plantilla del pedido de venta.

Módulos afectados:
account_invoice_sequence_by_sale_type

Cómo se prueba:
1. Crear pedido con plantilla “Alquiler”
2. Confirmar pedido y generar factura
3. Verificar que la factura tenga nombre tipo ALQ-0001