### PR TITLE
feat: crear módulo invoice_by_sale_type

### DIFF
--- a/custom_addons/invoice_by_sale_type/README.md
+++ b/custom_addons/invoice_by_sale_type/README.md
@@ -1,0 +1,34 @@
+## Español
+# Factura por tipo de venta
+
+Este módulo asigna automáticamente una secuencia a las facturas según la plantilla del pedido de venta relacionado, reemplazando la automatización creada originalmente con Studio.
+
+## Cómo probar
+
+1. Crear un pedido de venta con plantilla "Alquiler", "Maquina", etc.
+2. Confirmar el pedido.
+3. Generar la factura (en borrador).
+4. Verificar que el número de factura corresponde con la secuencia correspondiente.
+
+## Dependencias
+
+- account
+- sale
+
+## Inglés
+# Invoice by Sale Type
+
+This module assigns an invoice number automatically based on the sale order template used in the originating sale order.  
+It replaces a Studio automation with standard Odoo code for licensing and maintainability purposes.
+
+## Cómo probar
+
+1. Create a Sale Order using one of the predefined templates (Rental, Machine, etc.)
+2. Confirm the Sale Order
+3. Create the invoice from it
+4. Check that the invoice number has been auto-assigned according to the correct sequence
+
+## Dependencias
+
+- account
+- sale

--- a/custom_addons/invoice_by_sale_type/__init__.py
+++ b/custom_addons/invoice_by_sale_type/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_addons/invoice_by_sale_type/__manifest__.py
+++ b/custom_addons/invoice_by_sale_type/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Factura por tipo de venta',
+    'version': '1.0',
+    'summary': 'Asigna la secuencia según plantilla del pedido de venta',
+    'description': 'Este módulo reemplaza la automatización de Studio que asigna una secuencia a las facturas según el tipo de plantilla usada en el pedido de venta.',
+    'author': 'Salva M.',
+    'depends': ['account', 'sale'],
+    'data': [],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/custom_addons/invoice_by_sale_type/models/__init__.py
+++ b/custom_addons/invoice_by_sale_type/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/custom_addons/invoice_by_sale_type/models/account_move.py
+++ b/custom_addons/invoice_by_sale_type/models/account_move.py
@@ -1,0 +1,33 @@
+from odoo import models
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def write(self, vals):
+        '''
+        Reemplaza la acción de Studio que asignaba secuencia a la factura según
+        la plantilla del pedido de venta asociado, si estaba en borrador.
+        '''
+        for record in self:
+            if (
+                record.invoice_origin
+                and record.state == 'draft'
+                and (not record.name or record.name in ('/', 'Borrador'))
+            ):
+                sale_order = self.env['sale.order'].search(
+                    [('name', '=', record.invoice_origin)], limit=1
+                )
+                if sale_order and sale_order.sale_order_template_id:
+                    template_name = sale_order.sale_order_template_id.name
+                    sequence_mapping = {
+                        'Alquiler': 'sequence_factura_alquiler',
+                        'Maquina': 'sequence_factura_maquina',
+                        'Recambio': 'sequence_factura_recambio',
+                        'Reparacion': 'sequence_factura_reparacion',
+                    }
+                    sequence_id = sequence_mapping.get(template_name)
+                    if sequence_id:
+                        sequence = self.env['ir.sequence'].sudo().next_by_code(sequence_id)
+                        if sequence:
+                            vals['name'] = sequence
+        return super().write(vals)


### PR DESCRIPTION
Este módulo permite agrupar y diferenciar las facturas según el tipo de venta, añadiendo lógica específica en el modelo account.move.
Está diseñado para facilitar la segmentación contable y análisis financiero según la naturaleza de las ventas (por ejemplo: tienda, web, distribuidores, etc.).