### PR TITLE
feat: generar quality.checks por categoría y centro de trabajo sin necesidad de definir operación (#27)

### DIFF
--- a/custom_addons/quality_control_by_workcenter/models/__init__.py
+++ b/custom_addons/quality_control_by_workcenter/models/__init__.py
@@ -1,1 +1,2 @@
 from . import quality_point
+from . import mrp_production

--- a/custom_addons/quality_control_by_workcenter/models/mrp_production.py
+++ b/custom_addons/quality_control_by_workcenter/models/mrp_production.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from odoo import models, api # type: ignore
+
+"""
+Este módulo extiende el modelo de Quality Point para permitir la asignación de puntos de control a centros de trabajo específicos.
+"""
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for production in records:
+            production._generate_quality_checks_by_category_and_workcenter()
+        return records
+
+    def _generate_quality_checks_by_category_and_workcenter(self):
+        """Genera quality.checks por categoría de producto y centro de trabajo (workcenter_id), si no se define operación."""
+        self.ensure_one()
+        QualityCheck = self.env['quality.check']
+        Product = self.product_id
+        Categories = Product.categ_id
+
+        points = self.env['quality.point'].search([
+            ('product_category_ids', '!=', False),
+            ('workcenter_id', '!=', False),
+            ('operation_id', '=', False)
+        ])
+
+        for workorder in self.workorder_ids:
+            for point in points:
+                if (
+                    point.workcenter_id == workorder.workcenter_id and
+                    Categories in point.product_category_ids
+                ):
+                    QualityCheck.create({
+                        'workorder_id': workorder.id,
+                        'production_id': self.id,
+                        'point_id': point.id,
+                        'team_id': point.team_id.id,
+                        'company_id': self.company_id.id,
+                        'product_id': self.product_id.id,
+                    })

--- a/custom_addons/quality_control_by_workcenter/models/quality_point.py
+++ b/custom_addons/quality_control_by_workcenter/models/quality_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields
+from odoo import models, fields # type: ignore
 
 """
 Este módulo extiende el modelo de Quality Point para permitir la asignación de puntos de control a centros de trabajo específicos.


### PR DESCRIPTION
Resumen de cambios:
- Se ha completado el módulo quality_control_by_workcenter con una lógica personalizada para generar puntos de control (quality.check) basados en:
- Categorías de producto (product_category_ids)
- Centro de trabajo (workcenter_id)
- Sin necesidad de definir una operación específica (operation_id vacío)
- Esto permite que un solo quality.point se aplique automáticamente a múltiples productos y operaciones, siempre que pertenezcan a la categoría y se ejecuten en el centro de trabajo indicado.

Casos de uso clave:
"Inspección inicial" para todas las Operaciones de Entrada en productos de categoría Vapor, Barredora y Fregadora, sin duplicar el punto por producto ni operación.

Pasos para probar:
1. Crear un quality.point con:
2. product_category_ids: varias categorías
3. workcenter_id: ENTRADA (por ejemplo)
4. operation_id: vacío
5. Crear una orden de fabricación para un producto de una de esas categorías
6. Verificar que se genera un quality.check en la operación cuyo centro de trabajo coincida

Notas adicionales:
- El campo workcenter_id fue añadido al modelo quality.point
- La generación se realiza al crear la orden de fabricación (mrp.production)
- CI validado, módulo probado en entorno dev