### PR TITLE
feat: generación dinámica de quality.checks por producto, categoría o centro de trabajo (#29)

### DIFF
--- a/custom_addons/quality_control_by_workcenter/models/mrp_production.py
+++ b/custom_addons/quality_control_by_workcenter/models/mrp_production.py
@@ -49,21 +49,19 @@ class MrpProduction(models.Model):
 
         for workorder in self.workorder_ids:
             for point in points:
-                # Validar centro de trabajo obligatorio
                 if point.workcenter_id != workorder.workcenter_id:
                     continue
 
-                # Caso 1: punto de control asignado a un producto específico
-                if point.product_id and point.product_id != Product:
+                # Caso 1: punto definido por producto específico
+                if point.product_ids and Product not in point.product_ids:
                     continue
 
-                # Caso 2: punto de control por categoría
+                # Caso 2: punto por categoría
                 if point.product_category_ids and Category not in point.product_category_ids:
                     continue
 
-                # Caso 3: punto general (sin producto ni categoría) → se permite
+                # Caso 3: sin productos ni categorías → se aplica a todos
 
-                # Crear el quality.check vinculado al workorder correspondiente
                 QualityCheck.create({
                     'workorder_id': workorder.id,
                     'production_id': self.id,


### PR DESCRIPTION
Corrección incluida:

- Se corrigió un error en la validación de productos, donde se usaba product_id en lugar de product_ids (Many2many).
- Ahora se comprueba correctamente si el producto está presente en el conjunto product_ids.