### PR TITLE
fix: Lógica completa de asignación de secuencias por plantilla en pedidos de venta

### DIFF
--- a/custom_addons/custom_mrp_automation/__manifest__.py
+++ b/custom_addons/custom_mrp_automation/__manifest__.py
@@ -15,7 +15,7 @@
     'depends': ['mrp', 'stock'],
     "data": [        
     ],    
-    'application': True,
+    'application': False,
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',


### PR DESCRIPTION
## 📌 Descripción
Publicación en producción de la funcionalidad de secuencias personalizadas en pedidos de venta, basada en plantilla de presupuesto.

Incluye:
- Asignación automática de la plantilla "Reparacion" al crear desde orden de reparación.
- Generación de número de presupuesto por secuencia específica al guardar.
- Reasignación del número si se cambia la plantilla (solo en estado borrador).
- Prevención del consumo innecesario de secuencias.

## 📋 Tests realizados en `test`
- [ ] Creación de presupuesto con plantilla "Alquiler" → secuencia: PVAL/xxxxx
- [ ] Creación desde orden de reparación → asigna plantilla "Reparacion" y secuencia: PREP/xxxxx
- [ ] Cambio de plantilla mientras está en borrador → actualiza `name` correctamente.
- [ ] Confirmación → plantilla bloqueada, secuencia final mantenida.
- [ ] Sin consumo de secuencia en cambios visuales o sin guardar.

## ✅ ¿Cómo probarlo en producción?
1. Crear nuevo presupuesto y seleccionar distintas plantillas.
2. Confirmar comportamiento del campo `name` según plantilla.
3. Crear desde reparación y validar plantilla automática y numeración.
4. Confirmar presupuesto → bloquear edición.

## 📎 Notas adicionales
- Merge realizado desde `dev` a `test` mediante squash limpio.
- Validado funcionalmente por el equipo técnico en staging.
- Sin cambios en vistas ni archivos de datos que afecten a producción.

### 🔗 Commit final en `test`
#74 

## 🔍 Autor y revisor
**Autor:** @salvamc10 
**Revisor:** @salvamc10 