### PR TITLE
 feat: documentos obligatorios adjuntos automáticamente en plantillas de presupuesto

### DIFF
--- a/.github/workflows/odoo_ci.yml
+++ b/.github/workflows/odoo_ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - test
       - main
+      - dev
   pull_request:
     branches:
       - test
       - main
+      - dev
 
 jobs:
   odoo-tests:

--- a/custom_addons/custom_mrp_automation/__manifest__.py
+++ b/custom_addons/custom_mrp_automation/__manifest__.py
@@ -15,7 +15,7 @@
     'depends': ['mrp', 'stock'],
     "data": [        
     ],    
-    'application': True,
+    'application': False,
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',

--- a/custom_addons/custom_sale_required_docs/__init__.py
+++ b/custom_addons/custom_sale_required_docs/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_addons/custom_sale_required_docs/__manifest__.py
+++ b/custom_addons/custom_sale_required_docs/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'Documentos obligatorios en plantillas de presupuesto',
+    'version': '18.0.1.0',
+    'summary': 'Marca documentos obligatorios por plantilla y precárgalos en el pedido',
+    'license': 'LGPL-3',
+    'author': 'Salva M',
+    'category': 'Sales',
+    'depends': ['sale_pdf_quote_builder', 'sale_management'],
+    'description': """
+    Permite seleccionar, por plantilla de presupuesto, qué documentos del creador de presupuestos
+    son obligatorios. Al elegir la plantilla en el pedido, se marcan solo esos.
+    Aún así, los no obligatorios pero relevantes se pueden seleccionar manualmente.
+    """,
+    'data': [
+        'views/sale_order_template_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/custom_addons/custom_sale_required_docs/models/__init__.py
+++ b/custom_addons/custom_sale_required_docs/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_template, sale_order

--- a/custom_addons/custom_sale_required_docs/models/sale_order.py
+++ b/custom_addons/custom_sale_required_docs/models/sale_order.py
@@ -1,0 +1,26 @@
+from odoo import api, models
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _apply_required_docs_from_template(self):
+        for order in self:
+            tmpl = order.sale_order_template_id
+            order.quotation_document_ids = (
+                [(6, 0, tmpl.required_quotation_document_ids.ids)] if tmpl else [(5, 0, 0)]
+            )
+
+    @api.onchange('sale_order_template_id')
+    def _onchange_sale_order_template_id(self):
+        parent = getattr(super(), '_onchange_sale_order_template_id', None)
+        res = parent() if parent else {}
+        self._apply_required_docs_from_template()
+        return res
+
+    @api.model
+    def _add_missing_default_values(self, values):
+        values = super()._add_missing_default_values(values)
+        if not values.get('name'):
+            company_id = values.get('company_id') or self.env.company.id
+            values['name'] = self.env['ir.sequence'].with_company(company_id).next_by_code('sale.order') or 'New'
+        return values

--- a/custom_addons/custom_sale_required_docs/models/sale_order_template.py
+++ b/custom_addons/custom_sale_required_docs/models/sale_order_template.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+class SaleOrderTemplate(models.Model):
+    _inherit = 'sale.order.template'
+
+    required_quotation_document_ids = fields.Many2many(
+        'quotation.document',
+        'x_sale_tmpl_req_doc_rel', 'template_id', 'document_id',
+        string='Documentos obligatorios',
+        help='Se preseleccionarán en el pedido al elegir esta plantilla.',
+    )
+
+    @api.constrains('required_quotation_document_ids', 'quotation_document_ids')
+    def _check_required_subset(self):
+        for rec in self:
+            if rec.required_quotation_document_ids - rec.quotation_document_ids:
+                raise models.ValidationError(
+                    "Los documentos obligatorios deben estar también en 'Documentos' de la plantilla."
+                )

--- a/custom_addons/custom_sale_required_docs/views/sale_order_template_views.xml
+++ b/custom_addons/custom_sale_required_docs/views/sale_order_template_views.xml
@@ -5,11 +5,10 @@
     <field name="inherit_id" ref="sale_management.sale_order_template_view_form"/>
     <field name="arch" type="xml">
       <xpath expr="//field[@name='quotation_document_ids']" position="after">
-        <group string="Documentos obligatorios">
-          <label for="required_quotation_document_ids"/>
+        <group>
           <field name="required_quotation_document_ids"
-                  domain="[('id','in', quotation_document_ids)]"
-                  widget="many2many_tags"/>
+                domain="[('id','in', quotation_document_ids)]"
+                widget="many2many_tags"/>
           <div class="o_form_label">
             Solo se preseleccionan los marcados aquí. El resto quedan opcionales.
           </div>

--- a/custom_addons/custom_sale_required_docs/views/sale_order_template_views.xml
+++ b/custom_addons/custom_sale_required_docs/views/sale_order_template_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+  <record id="view_sale_order_template_form_inherit_required_docs" model="ir.ui.view">
+    <field name="name">sale.order.template.form.required.docs</field>
+    <field name="model">sale.order.template</field>
+    <field name="inherit_id" ref="sale_management.sale_order_template_view_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='quotation_document_ids']" position="after">
+        <group string="Documentos obligatorios">
+          <label for="required_quotation_document_ids"/>
+          <field name="required_quotation_document_ids"
+                  domain="[('id','in', quotation_document_ids)]"
+                  widget="many2many_tags"/>
+          <div class="o_form_label">
+            Solo se preseleccionan los marcados aquí. El resto quedan opcionales.
+          </div>
+        </group>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
📌 Descripción
Añade en plantillas de presupuesto la opción de marcar documentos obligatorios y los precarga automáticamente al crear un presupuesto.
Evita error de name NULL forzando secuencia por defecto en sale.order si falta.

📋 Tests realizados
- Precarga solo documentos obligatorios al elegir plantilla.
- Mantiene edición manual de documentos.
- Pedido sin plantilla → secuencia de Odoo se aplica.
- Sin impacto en eCommerce ni ventas estándar.

✅ ¿Cómo probarlo?
- [ ]     En plantilla, añadir documentos en Documentos obligatorios.
- [ ]     Crear presupuesto con esa plantilla → se cargan solo los obligatorios.
- [ ]     Quitar/añadir documentos y confirmar que no hay error de nombre.

📎 Notas adicionales
- Usa onchange para precarga y _add_missing_default_values para nombre.

🔗 Commit relacionado
#80 

🔍 Autor y revisor asignado
Autor: @Salva-BHIOR 
Revisor: @salvamc10 